### PR TITLE
Allow count for commands

### DIFF
--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -19,7 +19,9 @@ func (root *Root) moveLine(num int) {
 
 // Move up one screen.
 func (root *Root) movePgUp() {
-	n := root.Doc.lineNum - root.realHightNum()
+	count := root.countOr(1)
+
+	n := root.Doc.lineNum - (root.realHightNum() * count)
 	if n >= root.Doc.lineNum {
 		n = root.Doc.lineNum - 1
 	}
@@ -28,11 +30,13 @@ func (root *Root) movePgUp() {
 
 // Moves down one screen.
 func (root *Root) movePgDn() {
+	count := root.countOr(1)
+
 	n := root.bottomPos - root.Doc.Header
 	if n <= root.Doc.lineNum {
 		n = root.Doc.lineNum + 1
 	}
-	root.moveLine(n)
+	root.moveLine(n * count)
 }
 
 // realHightNum returns the actual number of line on the screen.
@@ -42,21 +46,27 @@ func (root *Root) realHightNum() int {
 
 // Moves up half a screen.
 func (root *Root) moveHfUp() {
-	root.moveLine(root.Doc.lineNum - (root.realHightNum() / 2))
+	count := root.countOr(1)
+
+	root.moveLine(root.Doc.lineNum - (root.realHightNum() / 2 * count))
 }
 
 // Moves down half a screen.
 func (root *Root) moveHfDn() {
-	root.moveLine(root.Doc.lineNum + (root.realHightNum() / 2))
+	count := root.countOr(1)
+
+	root.moveLine(root.Doc.lineNum + (root.realHightNum() / 2 * count))
 }
 
 // Move up one line.
 func (root *Root) moveUp() {
+	count := root.countOr(1)
+
 	root.resetSelect()
 
 	if !root.Doc.WrapMode {
 		root.Doc.branch = 0
-		root.Doc.lineNum--
+		root.Doc.lineNum -= count
 		return
 	}
 
@@ -74,7 +84,7 @@ func (root *Root) moveUp() {
 			yyLen := len(pre) / ((root.vWidth - root.startX) + 1)
 			root.Doc.branch = yyLen
 		}
-		root.Doc.lineNum--
+		root.Doc.lineNum -= count
 		return
 	}
 	root.Doc.branch--
@@ -82,11 +92,13 @@ func (root *Root) moveUp() {
 
 // Move down one line.
 func (root *Root) moveDown() {
+	count := root.countOr(1)
+
 	root.resetSelect()
 
 	if !root.Doc.WrapMode {
 		root.Doc.branch = 0
-		root.Doc.lineNum++
+		root.Doc.lineNum += count
 		return
 	}
 
@@ -98,7 +110,7 @@ func (root *Root) moveDown() {
 	branch := (len(lc) / (root.vWidth - root.startX))
 	if len(lc) < (root.vWidth-root.startX) || root.Doc.branch >= branch {
 		root.Doc.branch = 0
-		root.Doc.lineNum++
+		root.Doc.lineNum += count
 		return
 	}
 	root.Doc.branch++
@@ -106,10 +118,12 @@ func (root *Root) moveDown() {
 
 // Move to the left.
 func (root *Root) moveLeft() {
+	count := root.countOr(1)
+
 	root.resetSelect()
 	if root.Doc.ColumnMode {
 		if root.Doc.columnNum > 0 {
-			root.Doc.columnNum--
+			root.Doc.columnNum -= count
 			root.Doc.x = root.columnModeX()
 		}
 		return
@@ -117,7 +131,7 @@ func (root *Root) moveLeft() {
 	if root.Doc.WrapMode {
 		return
 	}
-	root.Doc.x--
+	root.Doc.x -= count
 	if root.Doc.x < root.minStartX {
 		root.Doc.x = root.minStartX
 	}
@@ -125,16 +139,18 @@ func (root *Root) moveLeft() {
 
 // Move to the right.
 func (root *Root) moveRight() {
+	count := root.countOr(1)
+
 	root.resetSelect()
 	if root.Doc.ColumnMode {
-		root.Doc.columnNum++
+		root.Doc.columnNum += count
 		root.Doc.x = root.columnModeX()
 		return
 	}
 	if root.Doc.WrapMode {
 		return
 	}
-	root.Doc.x++
+	root.Doc.x += count
 }
 
 // columnModeX returns the actual x from root.Doc.columnNum.
@@ -154,11 +170,13 @@ func (root *Root) columnModeX() int {
 
 // Move to the left by half a screen.
 func (root *Root) moveHfLeft() {
+	count := root.countOr(1)
+
 	if root.Doc.WrapMode {
 		return
 	}
 	root.resetSelect()
-	moveSize := (root.vWidth / 2)
+	moveSize := (root.vWidth / 2 * count)
 	if root.Doc.x > 0 && (root.Doc.x-moveSize) < 0 {
 		root.Doc.x = 0
 	} else {
@@ -171,6 +189,8 @@ func (root *Root) moveHfLeft() {
 
 // Move to the right by half a screen.
 func (root *Root) moveHfRight() {
+	count := root.countOr(1)
+
 	if root.Doc.WrapMode {
 		return
 	}
@@ -178,6 +198,6 @@ func (root *Root) moveHfRight() {
 	if root.Doc.x < 0 {
 		root.Doc.x = 0
 	} else {
-		root.Doc.x += (root.vWidth / 2)
+		root.Doc.x += (root.vWidth / 2 * count)
 	}
 }

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -79,6 +79,9 @@ type Root struct {
 
 	// cancelKeys represents the cancellation key string.
 	cancelKeys []string
+
+	// count for a command
+	count int
 }
 
 type lineNumber struct {
@@ -698,6 +701,23 @@ func (root *Root) toggleMouse() {
 	} else {
 		root.Screen.EnableMouse()
 		root.setMessage("Enable Mouse")
+	}
+}
+
+func (root *Root) addToCount(i int) {
+	root.count = root.count*10 + i
+	root.setMessage(fmt.Sprintf("%d", root.count))
+}
+
+func (root *Root) resetCount() {
+	root.count = 0
+}
+
+func (root *Root) countOr(i int) int {
+	if root.count != 0 {
+		return root.count
+	} else {
+		return 1
 	}
 }
 


### PR DESCRIPTION
Add the ability to enter a count prior to a command to e.g. jump 'count'
times. This is very similar to the behaviour of less.

At the moment this supports relative movements, but not absolute
movements (jumping to a specific line) as ov currently presents an
additional prompt for 'goto line' and doesn't provide a 'goto line' that
defaults to the last line (as less differentiates between `g` and `G`).