### PR TITLE
More less-like behaviour of `g` and `G`

### DIFF
--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -43,6 +43,7 @@ const (
 	actionHeader         = "header"
 	actionTabWidth       = "tabwidth"
 	actionGoLine         = "goto"
+	actionGoLineOrEnd    = "gotoOrEnd"
 	actionNextSearch     = "next_search"
 	actionNextBackSearch = "next_backsearch"
 	actionNextDoc        = "next_doc"
@@ -82,7 +83,8 @@ func (root *Root) setHandler() map[string]func() {
 		actionDelimiter:      root.setDelimiterMode,
 		actionHeader:         root.setHeaderMode,
 		actionTabWidth:       root.setTabWidthMode,
-		actionGoLine:         root.setGoLineMode,
+		actionGoLine:         root.setGoLine,
+		actionGoLineOrEnd:    root.setGoLineOrEnd,
 		actionNextSearch:     root.eventNextSearch,
 		actionNextBackSearch: root.eventNextBackSearch,
 		actionNextDoc:        root.nextDoc,
@@ -120,7 +122,7 @@ func GetKeyBinds(bind map[string][]string) map[string][]string {
 		actionWrap:           {"w", "W"},
 		actionColumnMode:     {"c"},
 		actionAlternate:      {"C"},
-		actionLineNumMode:    {"G"},
+		actionLineNumMode:    {"o"},
 		actionMark:           {"m"},
 		actionSearch:         {"/"},
 		actionBackSearch:     {"?"},
@@ -128,6 +130,7 @@ func GetKeyBinds(bind map[string][]string) map[string][]string {
 		actionHeader:         {"H"},
 		actionTabWidth:       {"t"},
 		actionGoLine:         {"g"},
+		actionGoLineOrEnd:    {"G"},
 		actionNextSearch:     {"n"},
 		actionNextBackSearch: {"N"},
 		actionNextDoc:        {"]"},

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -201,3 +201,23 @@ func (root *Root) moveHfRight() {
 		root.Doc.x += (root.vWidth / 2 * count)
 	}
 }
+
+func (root *Root) setGoLine() {
+	count := root.count
+
+	if count == 0 {
+		root.moveTop()
+	} else {
+		root.moveLine(count - 1)
+	}
+}
+
+func (root *Root) setGoLineOrEnd() {
+	count := root.count
+
+	if count == 0 {
+		root.moveBottom()
+	} else {
+		root.moveLine(count - 1)
+	}
+}


### PR DESCRIPTION
In less `g` and `G` behave the same when prepended with a count.
Without a count `g` jumps to the beginning of the file and `G` jumps to
the end of the file.

This changes conflicts with the current behaviour of ov as both `g` and
`G` are already mapped, but with a different behaviour.

`g` was already a keybinding to jump to a specific line. However,
currently this opens an input mode for the line number (as opposed to
using a count) and doesn't have a default.

`G` was already a keybinding to toggle line numbers. This keybinding was
changed to `o`.