### PR TITLE
Shorten keybindings in help view

### DIFF
--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -233,5 +233,16 @@ func KeyBindString(k KeyBind) string {
 }
 
 func (k KeyBind) writeKeyBind(w io.Writer, action string, detail string) {
-	fmt.Fprintf(w, "  %-26s * %s\n", "["+strings.Join(k[action], "], [")+"]", detail)
+	shortened := shortenKeyBinds(k[action])
+	shortcuts := strings.Join(shortened, "], [")
+	fmt.Fprintf(w, "  %-26s * %s\n", "["+shortcuts+"]", detail)
+}
+
+func shortenKeyBinds(shortcuts []string) []string {
+	shortened := make([]string, len(shortcuts))
+	copy(shortened, shortcuts)
+	for i, s := range shortcuts {
+		shortened[i] = strings.Replace(s, "ctrl+", "^", 1)
+	}
+	return shortened
 }


### PR DESCRIPTION
Display keybindings involving the "ctrl" key with the shorthand "^".
So instead of "ctrl+c" it displays "^c".

This leads to a denser and more readable display of the keybindings.